### PR TITLE
#4 : LateInitializationError solved

### DIFF
--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -95,6 +95,7 @@ class HomePage extends StatelessWidget {
               crossAxisCount: 4,
               mainAxisSpacing: 8,
               crossAxisSpacing: 8,
+              axisDirection: AxisDirection.down,
               children: [
                 for (int i = 0; i < _notesController.noteList.length; i++)
                   StaggeredGridTile.count(


### PR DESCRIPTION
After upgrading to Flutter 3.7.0 this error popped out from staggered grid view.
Assigning value to the parameter "axisDirection" solves the issue.
Solution thread : https://github.com/letsar/flutter_staggered_grid_view/issues/285